### PR TITLE
Updating README with ssr settings for SvelteKit

### DIFF
--- a/projects/svelte-localstorage/README.md
+++ b/projects/svelte-localstorage/README.md
@@ -20,6 +20,9 @@ const config = {
 			optimizeDeps: {
 				exclude: ["@babichjacob/svelte-localstorage"],
 			},
+			ssr: {
+				noExternal: ["@babichjacob/svelte-localstorage"],
+			},
 		}
 	}
 };


### PR DESCRIPTION
The fix you suggested in #18 worked fine for client side scripts, but not for SSR. If i visited a page that was using the script, i got an error.

By adding this library to `kit.vite.ssr.noExternal`, it works with SSR as well.

This PR includes an update to the **README.md** with the above mentioned configuration.