### PR TITLE
Change syntax in README.md from json to jsonc

### DIFF
--- a/projects/svelte-localstorage/README.md
+++ b/projects/svelte-localstorage/README.md
@@ -9,7 +9,7 @@ npm install --save-dev @babichjacob/svelte-localstorage
 
 ### ⌨️ TypeScript
 This package uses JSDoc for types and documentation, so an extra step is needed to use it in TypeScript projects [for now](https://github.com/babichjacob/svelte-localstorage/issues/22). Configure your `tsconfig.json` so that it has `compilerOptions.maxNodeModuleJsDepth` set to at least 1:
-```json
+```jsonc
 // tsconfig.json
 {
 	// When using SvelteKit: "extends": "./.svelte-kit/tsconfig.json",


### PR DESCRIPTION
Change syntax highlighting in `README.md` from `json` to `jsonc` so that it renders the comments in the `.json` file in a nicer way 🙂